### PR TITLE
Misspelled command might crash the start_link fun

### DIFF
--- a/lib/stack_supervisored/sup_supervisor.ex
+++ b/lib/stack_supervisored/sup_supervisor.ex
@@ -3,7 +3,7 @@ defmodule StackSupervisored.SupSupervisor do
   use Supervisor
 
   def start_link(state_pid) do
-    IO.pust "start supsupervisor"
+    IO.puts "start supsupervisor"
     {:ok, _pid} = Supervisor.start_link(__MODULE__, state_pid)
   end
   


### PR DESCRIPTION
Hi. I haven't tried running it, but try this out.
